### PR TITLE
[Security] Add CSRF state token to OAuth2 Flow [SRE-426]

### DIFF
--- a/internal/webserver/webserver.go
+++ b/internal/webserver/webserver.go
@@ -30,12 +30,11 @@ var (
 		Scopes:       []string{"https://www.googleapis.com/auth/userinfo.email"},
 		Endpoint:     google.Endpoint,
 	}
-	oauthStateStringGl = ""
-	log                *logger.Logger
-	sessionStorage     *sessions.CookieStore
-	helmCommand        = ""
-	clientset          *kubernetes.Clientset
-	slackClient        = slack.New(os.Getenv("SLACK_APP_HELM_OAUTH_TOKEN"))
+	log            *logger.Logger
+	sessionStorage *sessions.CookieStore
+	helmCommand    = ""
+	clientset      *kubernetes.Clientset
+	slackClient    = slack.New(os.Getenv("SLACK_APP_HELM_OAUTH_TOKEN"))
 )
 
 func HealthHandler(response http.ResponseWriter, request *http.Request) {
@@ -84,7 +83,6 @@ func HandleHTTP(GoogleClientID string, GoogleClientSecret string, port string) {
 	}
 	oauthConfGl.ClientID = GoogleClientID
 	oauthConfGl.ClientSecret = GoogleClientSecret
-	oauthStateStringGl = ""
 	log.InfoF("Inside Go Func...\n")
 	r := mux.NewRouter()
 	loggedRouter := handlers.LoggingHandler(os.Stdout, r)


### PR DESCRIPTION
The state token was always the empty string, which defeats this CSRF
mechanism of OAuth2. Fortunately, internal clients aren't very
vulnerable to the common CSRF attack against OAuth2 server flows, but
this check must still be done to satisfy the OAuth2 specification.

See more: https://tools.ietf.org/html/rfc6749#section-10.12