### PR TITLE
Remove explicit TLS, + use Kong, in Sandbox [SRE-454]

### DIFF
--- a/deployments/helm/helm-rollback-web/values.sandbox.yaml
+++ b/deployments/helm/helm-rollback-web/values.sandbox.yaml
@@ -44,7 +44,9 @@ helmrollbackweb:
 ingress:
   enabled: true
   annotations: 
-    kubernetes.io/ingress.class: traefik
+    kubernetes.io/ingress.class: kong-public
+    konghq.com/protocols: "https"
+    konghq.com/https-redirect-status-code: "301"
   hosts:
     - host: helm-rollback.forto.io
       paths:


### PR DESCRIPTION
This shouldn't be necessary at all, because there's a wildcard in the cluster.

~~I'm keeping this separate from switching to Kong despite touching nearly the same lines of YAML.~~