### PR TITLE
bump mem allocation to 256Mi

### DIFF
--- a/deployments/helm/helm-rollback-web/values.production.yaml
+++ b/deployments/helm/helm-rollback-web/values.production.yaml
@@ -54,10 +54,10 @@ resources: {}
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
   #   cpu: 100m
-  #   memory: 128Mi
+  #   memory: 256Mi
   # requests:
   #   cpu: 100m
-  #   memory: 128Mi
+  #   memory: 256Mi
 
 nodeSelector: {}
 

--- a/deployments/helm/helm-rollback-web/values.sandbox.yaml
+++ b/deployments/helm/helm-rollback-web/values.sandbox.yaml
@@ -47,17 +47,17 @@ ingress:
       paths:
       - /
 
-resources:
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  limits:
+  # limits:
   #   cpu: 100m
-    memory: 256Mi
-  requests:
+  #   memory: 256Mi
+  # requests:
   #   cpu: 100m
-    memory: 256Mi
+  #   memory: 256Mi
 
 nodeSelector: {}
 

--- a/deployments/helm/helm-rollback-web/values.yaml
+++ b/deployments/helm/helm-rollback-web/values.yaml
@@ -55,11 +55,10 @@ helmrollbackweb:
 resources:
   limits:
     cpu: 1000m
-    memory: 128Mi
+    memory: 256Mi
   requests:
     cpu: 10m
-    # this should be ~64Mi, but leaving equal to limits for now:
-    memory: 128Mi
+    memory: 256Mi
 
 nodeSelector: {}
 


### PR DESCRIPTION
Related to the helm-rollback-web incident, discussed [here](https://forto.slack.com/archives/G015F8TS20Z/p1624268277135500)