### PR TITLE
[SP-746] list pending releases

### DIFF
--- a/internal/webserver/api.go
+++ b/internal/webserver/api.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strings"
 
 	slack "github.com/slack-go/slack"
 )
@@ -48,8 +49,10 @@ func HelmListHandler(response http.ResponseWriter, request *http.Request) {
 		UnauthorizedHandler(response, request)
 		return
 	}
-	log.Info("Executing `" + helmCommand + " list -o json --all-namespaces --time-format 2006-01-02T15:04:05Z")
-	out, err := exec.Command(helmCommand, "list", "-o", "json", "--all-namespaces", "--time-format", "2006-01-02T15:04:05Z").Output()
+	helmArgs := "list -a -o json --all-namespaces --time-format 2006-01-02T15:04:05Z"
+	log.Info("Executing `" + helmCommand + " " + helmArgs + "`")
+	sliceArgs := strings.Fields(helmArgs)
+	out, err := exec.Command(helmCommand, sliceArgs...).Output()
 	if err != nil {
 		log.Error(err.Error())
 		ServerErrorHandler(response, request)


### PR DESCRIPTION
We have seen interrupted "pending_upgrade" releases block builds with error "UPGRADE FAILED: another operation (install/upgrade/rollback) is in progress". 
But devs can't rollback by web because the default helm list does not include releases in that state, for legacy reasons:
https://github.com/helm/helm/issues/9442 (so it *might* get fixed in helm4).

Added "-a" to list args here, also cleaned up the command line presentation a bit.