### PR TITLE
chore(deploy): Enable VerticalPodAutoscaler

### DIFF
--- a/deployments/helm/helm-rollback-web/values.yaml
+++ b/deployments/helm/helm-rollback-web/values.yaml
@@ -21,6 +21,8 @@ forto-app:
     deployments:
       api:
         replicaCount: 1
+        verticalPodAutoscaler:
+          enabled: true
         containers:
         - probes:
             enabled: true


### PR DESCRIPTION
This application has a bit of a weirder memory usage pattern since we run `helm list` as a subcommand on-demand. Let's see how it performs.

JIRA: SP-1222