### PR TITLE
chore(deploy): Revert "Enable VerticalPodAutoscaler (#285)"

### DIFF
--- a/deployments/helm/helm-rollback-web/values.yaml
+++ b/deployments/helm/helm-rollback-web/values.yaml
@@ -21,8 +21,6 @@ forto-app:
     deployments:
       api:
         replicaCount: 1
-        verticalPodAutoscaler:
-          enabled: true
         containers:
         - probes:
             enabled: true


### PR DESCRIPTION
This reverts commit 41677f46ea9f08cb0a793daf4edad2a932266cd3. The reason for this revert is that the memory footprint is too spiky for full automatic VPA to know how to handle.