### PR TITLE
chore: 🧹 Resolve CircleCI Docker Version problem (autofix)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ workflows:
           image: helm-rollback-web
           tag: ${CIRCLE_SHA1}
           # https://circleci.com/docs/2.0/building-docker-images/#docker-version
-          remote-docker-version: 20.10.18
+          remote-docker-version: default
           setup-remote-docker: true
           use-docker-layer-caching: true
 


### PR DESCRIPTION
### Check description:
Finds and fixes pinned 'remote docker' versions, which are being removed by CircleCI

### Problem summary:
Uses CircleCI docker 20.10.18

#### In `.circleci/config.yml`:
* CircleCI is removing docker version 20.10.18 (line 23)

### :broom: Authored using Repo Nanny
https://repo-nanny.forto.tools/repos/helm-rollback-web