### PR TITLE
chore: 🧹 Resolve CircleCI GCP Secrets problem (autofix)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  gcp-gcr: circleci/gcp-gcr@0.15
+  gcp-gcr: circleci/gcp-gcr@0.16
   helm3-deploy: freighthub/helm3-deploy@1.3
 executors:
   build:
@@ -14,9 +14,10 @@ workflows:
       - gcp-gcr/build-and-push-image:
           name: Build Image
           executor: build
-          context: gcloud-registry
+          context: gcp-oidc-docker-registry
           dockerfile: build/package/Dockerfile
           registry-url: eu.gcr.io
+          use_oidc: true
           image: helm-rollback-web
           tag: ${CIRCLE_SHA1}
           # https://circleci.com/docs/2.0/building-docker-images/#docker-version
@@ -27,9 +28,9 @@ workflows:
       - helm3-deploy/diff-deploy:
           name: Diff against Sandbox
           context:
-              - gcloud-sandbox
+              - gcp-oidc-deployer-sandbox
+              - sops-credential
               - github
-          cluster_name: $PLAYGROUND
           namespace: sre-tooling
           values_base: sandbox
           chart_path: deployments/helm/helm-rollback-web
@@ -37,9 +38,9 @@ workflows:
       - helm3-deploy/diff-deploy:
           name: Diff against Production
           context:
-              - gcloud-production
+              - gcp-oidc-deployer-production
+              - sops-credential
               - github
-          cluster_name: $GCLOUD_CLUSTER_NAME
           namespace: sre-tooling
           values_base: production
           chart_path: deployments/helm/helm-rollback-web
@@ -49,10 +50,10 @@ workflows:
           chart_path: deployments/helm/helm-rollback-web
           values_base: sandbox
           release_name: $CIRCLE_PROJECT_REPONAME
-          cluster_name: $PLAYGROUND
           namespace: sre-tooling
           context:
-              - gcloud-sandbox
+              - gcp-oidc-deployer-sandbox
+              - sops-credential
               - github
           requires:
             - Build Image
@@ -66,10 +67,10 @@ workflows:
           chart_path: deployments/helm/helm-rollback-web
           values_base: production
           release_name: $CIRCLE_PROJECT_REPONAME
-          cluster_name: $GCLOUD_CLUSTER_NAME
           namespace: sre-tooling
           context:
-              - gcloud-production
+              - gcp-oidc-deployer-production
+              - sops-credential
               - github
           requires:
             - Build Image


### PR DESCRIPTION
### Check description:
Finds usage of static credentials for GCP in CircleCI configurations, and helps replace them with passwordless access.

### Problem summary:
Uses static credentials: gcloud-registry, gcloud-sandbox, gcloud-production

#### In `.circleci/config.yml`:
* GCR Push Orb should authenticate with OIDC (line 20)
* Job "gcp-gcr/build-and-push-image" should use passwordless access to GCR (line 17)
* Job "helm3-deploy/diff-deploy" should use passwordless access to Kubernetes (line 30)
* Our helm orb only uses OIDC when cluster_name is not supplied (line 32)
* Job "helm3-deploy/diff-deploy" should use passwordless access to Kubernetes (line 40)
* Our helm orb only uses OIDC when cluster_name is not supplied (line 42)
* Job "helm3-deploy/main-deploy" should use passwordless access to Kubernetes (line 55)
* Our helm orb only uses OIDC when cluster_name is not supplied (line 52)
* Job "helm3-deploy/main-deploy" should use passwordless access to Kubernetes (line 72)
* Our helm orb only uses OIDC when cluster_name is not supplied (line 69)
* 'circleci/gcp-gcr' only supports passwordless access since 0.16 (line 3)

### :broom: Authored using Repo Nanny
https://repo-nanny.forto.tools/repos/helm-rollback-web