### PR TITLE
chore: 🧹 Resolve Docker Artifact Registry problem (autofix)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,11 +14,11 @@ workflows:
       - gcp-gcr/build-and-push-image:
           name: Build Image
           executor: build
-          context: gcp-oidc-docker-registry
+          context: gcp-oidc-artifact-registry
           dockerfile: build/package/Dockerfile
-          registry-url: eu.gcr.io
+          registry-url: europe-west1-docker.pkg.dev
           use_oidc: true
-          image: helm-rollback-web
+          image: docker/helm-rollback-web
           tag: ${CIRCLE_SHA1}
           # https://circleci.com/docs/2.0/building-docker-images/#docker-version
           remote-docker-version: default

--- a/deployments/helm/helm-rollback-web/values.yaml
+++ b/deployments/helm/helm-rollback-web/values.yaml
@@ -4,7 +4,7 @@ forto-app:
     team: sre
     repository: https://github.com/freight-hub/helm-rollback-web
   image:
-    repository: eu.gcr.io/freighthub-registry/helm-rollback-web
+    repository: europe-west1-docker.pkg.dev/forto-artifacts/docker/helm-rollback-web
   app:
     env:
       HELM_ROLLBACK_WEB_OIDC_ISSUER: https://accounts.google.com


### PR DESCRIPTION
### Check description:
Migrates our Docker images from Google Container Registry to Google Artifact Registry.

JIRA ticket: [BP-2182](https://forto.atlassian.net/browse/BP-2182)

### Problem summary:
Deployment pipeline uses legacy GCR

> Google Container Registry is being shut down by next year. We are migrating to Google Artifact Registry.

#### In `.circleci/config.yml`:
* Use Google Artifact Registry for docker artifacts. (line 19)
* Use Google Artifact Registry for docker artifacts. (line 21)
* Use our new project for docker artifacts. (line 17)

#### In `./deployments/helm/helm-rollback-web/values.yaml`:
* Reference Google Artifact Registry for docker artifacts. (line 7)

### :broom: Authored using Repo Nanny
https://repo-nanny.forto.tools/repos/helm-rollback-web

[BP-2182]: https://forto.atlassian.net/browse/BP-2182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ