### PR TITLE
chore: 🧹 Autofix CircleCI Github Token problem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   gcp-gcr: circleci/gcp-gcr@0.16
-  helm3-deploy: freighthub/helm3-deploy@1.3
+  helm3-deploy: freighthub/helm3-deploy@2.0
 executors:
   build:
     docker:
@@ -30,7 +30,7 @@ workflows:
           context:
               - gcp-oidc-deployer-sandbox
               - sops-credential
-              - github
+              - github-oidc
           namespace: sre-tooling
           values_base: sandbox
           chart_path: deployments/helm/helm-rollback-web
@@ -40,7 +40,7 @@ workflows:
           context:
               - gcp-oidc-deployer-production
               - sops-credential
-              - github
+              - github-oidc
           namespace: sre-tooling
           values_base: production
           chart_path: deployments/helm/helm-rollback-web
@@ -54,7 +54,7 @@ workflows:
           context:
               - gcp-oidc-deployer-sandbox
               - sops-credential
-              - github
+              - github-oidc
           requires:
             - Build Image
           filters:
@@ -71,7 +71,7 @@ workflows:
           context:
               - gcp-oidc-deployer-production
               - sops-credential
-              - github
+              - github-oidc
           requires:
             - Build Image
           filters:


### PR DESCRIPTION
### Check description:
Audits CircleCI pipelines for references to our github static credential. [SRE-2462](https://forto.atlassian.net/browse/SRE-2462)

With this change, CI will be commenting on your PRs as "forto-ci (bot)" instead of "FreightBot"

### Problem summary:
Autofix available for [helm-orb]

#### In `.circleci/config.yml`:
* Using previous version of 'freighthub/helm3-deploy' (line 4)
* Replace Github token context with a passwordless context. (line 33)
* Replace Github token context with a passwordless context. (line 43)
* Replace Github token context with a passwordless context. (line 57)
* Replace Github token context with a passwordless context. (line 74)

### :broom: Authored using Repo Nanny
https://repo-nanny.forto.tools/repos/helm-rollback-web

@coderabbitai ignore

[SRE-2462]: https://forto.atlassian.net/browse/SRE-2462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ