### PR TITLE
chore: 🧹 Autofix SOPS Deprecation problem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,6 @@ workflows:
           name: Diff against Sandbox
           context:
               - gcp-oidc-deployer-sandbox
-              - sops-credential
               - github-oidc
           namespace: sre-tooling
           values_base: sandbox
@@ -43,7 +42,6 @@ workflows:
           name: Diff against Production
           context:
               - gcp-oidc-deployer-production
-              - sops-credential
               - github-oidc
           namespace: sre-tooling
           values_base: production
@@ -61,7 +59,6 @@ workflows:
           namespace: sre-tooling
           context:
               - gcp-oidc-deployer-sandbox
-              - sops-credential
               - github-oidc
           requires:
             - Build Image
@@ -78,7 +75,6 @@ workflows:
           namespace: sre-tooling
           context:
               - gcp-oidc-deployer-production
-              - sops-credential
               - github-oidc
           requires:
             - Build Image


### PR DESCRIPTION
### Check description:
Detects SOPS files in the Git repository to ensure secrets are securely managed. [SRE-2677](https://forto.atlassian.net/browse/SRE-2677)

Forto is moving away from storing secrets as SOPS files inside Git repositories. The existing secrets will be imported into Infisical and the SOPS files will be deleted from your `deploy/` folder.

For more details, please review: [Migration of deployment secrets from SOPS to Infisical](https://forto.atlassian.net/wiki/spaces/SRE/pages/5535957025/Migration+of+deployment+secrets+from+SOPS+to+Infisical)

### Problem summary:
Some remnants of SOPS are still present

> Please migrate the application's deployment secrets to Infisical.

#### In `.circleci/config.yml`:
* Remove sops-credential context from CircleCI config (line 32)
* Remove sops-credential context from CircleCI config (line 46)
* Remove sops-credential context from CircleCI config (line 64)
* Remove sops-credential context from CircleCI config (line 81)

### :broom: Authored using Repo Nanny
https://repo-nanny.forto.tools/repos/helm-rollback-web

@coderabbitai ignore

[SRE-2677]: https://forto.atlassian.net/browse/SRE-2677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ