### PR TITLE
chore: 🧹 Autofix Docker Image Repository Labels problem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ workflows:
       - gcp-gcr/build-and-push-image:
           name: Build Image
           executor: build
+          extra_build_args: '--label org.opencontainers.image.source=https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME --label org.opencontainers.image.revision=$CIRCLE_SHA1'
           context: gcp-oidc-artifact-registry
           dockerfile: build/package/Dockerfile
           registry-url: europe-west1-docker.pkg.dev


### PR DESCRIPTION
SRE-2762
### Check description:
Ensures Docker images pushed via gcp-gcr/build-and-push-image include labels for artifact tracing.

### Problem summary:
Docker image push is missing OCI image labels (source, revision)

#### In `.circleci/config.yml`:
* Missing extra_build_args with OCI image labels (line 34)

### :broom: Authored using Repo Nanny
https://repo-nanny.forto.tools/repos/helm-rollback-web

@coderabbitai ignore