### PR TITLE
chore: 🧹 Autofix CircleCI Executors problem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,11 @@ orbs:
   helm-push: freighthub/helm-push@0.1
 executors:
   build:
+    resource_class: medium.gen2
     docker:
-      - image: cimg/base:2024.06
+      - image: cimg/base:2026.08
   node:
+    resource_class: medium.gen2
     docker:
       - image: cimg/node:25.5
 jobs:


### PR DESCRIPTION
### Check description:
CircleCI has been shipping new "generations" of executor classes, which claim to have higher multithreaded performance. [SRE-3136](https://forto.atlassian.net/browse/SRE-3136)

[Announcement blog post from CircleCI](https://circleci.com/changelog/introducing-gen2-docker-x86-resource-classes/)

### Problem summary:
Desired changes to [ executors.build, executors.node ]

#### In `.circleci/config.yml`:
* Image for executors.build is outdated (line 9)
* Add a gen2 resource class to executors.build (line 7)
* Add a gen2 resource class to executors.node (line 10)

### :broom: Authored using Repo Nanny
https://repo-nanny.forto.tools/repos/helm-rollback-web

@coderabbitai ignore



[SRE-3136]: https://forto.atlassian.net/browse/SRE-3136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ